### PR TITLE
[ISSUE-12] Adding -Dconsul.dns.off flag to allow execution on Mac

### DIFF
--- a/dockerunit-consul/pom.xml
+++ b/dockerunit-consul/pom.xml
@@ -3,7 +3,7 @@
 <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.qzagarese</groupId>
   <artifactId>dockerunit-consul</artifactId>
-  <version>1.0.1-GA-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <name>dockerunit-consul</name>
   <description>Java Framework for testing of dockerised applications and services. Consul+registrator based service discovery package.</description>
   <url>https://github.com/qzagarese/dockerunit</url>
@@ -15,7 +15,7 @@
   </developers>
 
   <properties>
-    <dockerunit.core.version>1.0.1-GA-SNAPSHOT</dockerunit.core.version>
+    <dockerunit.core.version>1.0.1-SNAPSHOT</dockerunit.core.version>
     <vertx.core.version>3.5.4</vertx.core.version>
     <lombok.version>1.16.6</lombok.version>
   </properties>

--- a/dockerunit-consul/pom.xml
+++ b/dockerunit-consul/pom.xml
@@ -3,7 +3,7 @@
 <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.qzagarese</groupId>
   <artifactId>dockerunit-consul</artifactId>
-  <version>1.0.0-GA</version>
+  <version>1.0.1-GA-SNAPSHOT</version>
   <name>dockerunit-consul</name>
   <description>Java Framework for testing of dockerised applications and services. Consul+registrator based service discovery package.</description>
   <url>https://github.com/qzagarese/dockerunit</url>
@@ -15,7 +15,7 @@
   </developers>
 
   <properties>
-    <dockerunit.core.version>1.0.0-GA</dockerunit.core.version>
+    <dockerunit.core.version>1.0.1-GA-SNAPSHOT</dockerunit.core.version>
     <vertx.core.version>3.5.4</vertx.core.version>
     <lombok.version>1.16.6</lombok.version>
   </properties>

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDescriptor.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDescriptor.java
@@ -40,9 +40,9 @@ public class ConsulDescriptor {
             bindings = new Ports();
         }
 
-        Optional<String> disableDnsFlag = Optional.ofNullable(System.getProperty(CONSUL_DNS_OFF_PROPERTY, CONSUL_DNS_OFF_DEFAULT));
+        boolean enableDnsFlag = Boolean.parseBoolean(System.getProperty(CONSUL_DNS_ENABLED_PROPERTY, CONSUL_DNS_ENABLED_DEFAULT));
 
-        if(!disableDnsFlag.isPresent()) {
+        if(enableDnsFlag) {
             activateDns(ports, bindings);
         } else {
             logger.warning("Consul DNS has been disabled. Usages of @" + UseConsulDns.class.getSimpleName() + " will be ignored.");

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDescriptor.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDescriptor.java
@@ -21,45 +21,45 @@ import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryCo
 @Image("consul:1.0.0")
 public class ConsulDescriptor {
 
-	
-	static final int CONSUL_DNS_PORT = 8600;
-	static final int CONSUL_PORT = 8500;
+
+    static final int CONSUL_DNS_PORT = 8600;
+    static final int CONSUL_PORT = 8500;
 
     private static final Logger logger = Logger.getLogger(ConsulDescriptor.class.getSimpleName());
 
 
     @ContainerBuilder
-	public CreateContainerCmd setup(CreateContainerCmd cmd) {
-		List<ExposedPort> ports = new ArrayList<>(Arrays.asList(cmd.getExposedPorts()));
+    public CreateContainerCmd setup(CreateContainerCmd cmd) {
+        List<ExposedPort> ports = new ArrayList<>(Arrays.asList(cmd.getExposedPorts()));
 
         ExposedPort consulPort = ExposedPort.tcp(CONSUL_PORT);
         ports.add(consulPort);
-        
+
         Ports bindings = cmd.getPortBindings();
         if (bindings == null) {
             bindings = new Ports();
         }
-        
+
         Optional<String> disableDnsFlag = Optional.ofNullable(System.getProperty(CONSUL_DNS_OFF_PROPERTY, CONSUL_DNS_OFF_DEFAULT));
 
         if(!disableDnsFlag.isPresent()) {
             activateDns(ports, bindings);
         } else {
-            logger.warning("Consul dns has been disabled. Usages of @" + UseConsulDns.class.getSimpleName() + " will not sort any effect.");
+            logger.warning("Consul DNS has been disabled. Usages of @" + UseConsulDns.class.getSimpleName() + " will be ignored.");
         }
-        
+
         bindings.bind(consulPort, Binding.bindPort(8500));
 
         return cmd.withExposedPorts(ports)
-            .withPortBindings(bindings)
-            .withCmd("agent", "-dev", "-client=0.0.0.0", "-enable-script-checks");
+                .withPortBindings(bindings)
+                .withCmd("agent", "-dev", "-client=0.0.0.0", "-enable-script-checks");
 
-	}
+    }
 
     private void activateDns(List<ExposedPort> ports, Ports bindings) {
         ExposedPort dnsPort = ExposedPort.udp(CONSUL_DNS_PORT);
         ports.add(dnsPort);
-        
+
         int dnsBridgePort = Integer.parseInt(System.getProperty(CONSUL_DNS_PORT_BRIDGE_BINDING,
                 CONSUL_DNS_PORT_BRIDGE_BINDING_DEFAULT));
 

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDescriptor.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDescriptor.java
@@ -1,12 +1,5 @@
 package com.github.qzagarese.dockerunit.discovery.consul;
 
-import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryConfig.*;
-import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryConfig.DOCKER_BRIDGE_IP_PROPERTY;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.Ports;
@@ -14,6 +7,14 @@ import com.github.dockerjava.api.model.Ports.Binding;
 import com.github.qzagarese.dockerunit.annotation.ContainerBuilder;
 import com.github.qzagarese.dockerunit.annotation.Image;
 import com.github.qzagarese.dockerunit.annotation.Named;
+import com.github.qzagarese.dockerunit.discovery.consul.annotation.UseConsulDns;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryConfig.*;
 
 @Named("consul")
 @Image("consul:1.0.0")
@@ -23,7 +24,10 @@ public class ConsulDescriptor {
 	static final int CONSUL_DNS_PORT = 8600;
 	static final int CONSUL_PORT = 8500;
 
-	@ContainerBuilder
+    private static final Logger logger = Logger.getLogger(ConsulDescriptor.class.getSimpleName());
+
+
+    @ContainerBuilder
 	public CreateContainerCmd setup(CreateContainerCmd cmd) {
 		List<ExposedPort> ports = new ArrayList<>(Arrays.asList(cmd.getExposedPorts()));
         ExposedPort dnsPort = ExposedPort.udp(CONSUL_DNS_PORT);
@@ -37,12 +41,19 @@ public class ConsulDescriptor {
             bindings = new Ports();
         }
         
-        int dnsBridgePort = Integer.parseInt(System.getProperty(CONSUL_DNS_PORT_BRIDGE_BINDING, 
-                CONSUL_DNS_PORT_BRIDGE_BINDING_DEFAULT));
+        String consulDnsFlagOff = System.getProperty(CONSUL_DNS_OFF_PROPERTY, CONSUL_DNS_OFF_DEFAULT);
 
-        bindings.bind(dnsPort, Binding.bindIpAndPort(
-                System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT), 
-                dnsBridgePort));
+        if(consulDnsFlagOff == null) {
+            int dnsBridgePort = Integer.parseInt(System.getProperty(CONSUL_DNS_PORT_BRIDGE_BINDING,
+                    CONSUL_DNS_PORT_BRIDGE_BINDING_DEFAULT));
+
+            bindings.bind(dnsPort, Binding.bindIpAndPort(
+                    System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT),
+                    dnsBridgePort));
+        } else {
+            logger.warning("Consul dns has been disabled. Usages of @" + UseConsulDns.class.getSimpleName() + " will not sort any effect.");
+        }
+        
         bindings.bind(consulPort, Binding.bindPort(8500));
 
         return cmd.withExposedPorts(ports)

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDiscoveryConfig.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDiscoveryConfig.java
@@ -15,7 +15,7 @@ public class ConsulDiscoveryConfig {
 	public static final String CONSUL_POLLING_PERIOD_DEFAULT = "1";
 	public static final String CONSUL_DNS_PORT_BRIDGE_BINDING = "consul.dns.port.bridge.binding";
 	public static final String CONSUL_DNS_PORT_BRIDGE_BINDING_DEFAULT = "53";
-	public static final String CONSUL_DNS_OFF_PROPERTY = "consul.dns.off";
-	public static final String CONSUL_DNS_OFF_DEFAULT = null;
+	public static final String CONSUL_DNS_ENABLED_PROPERTY = "consul.dns.enabled";
+	public static final String CONSUL_DNS_ENABLED_DEFAULT = "true";
 
 }

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDiscoveryConfig.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDiscoveryConfig.java
@@ -15,6 +15,7 @@ public class ConsulDiscoveryConfig {
 	public static final String CONSUL_POLLING_PERIOD_DEFAULT = "1";
 	public static final String CONSUL_DNS_PORT_BRIDGE_BINDING = "consul.dns.port.bridge.binding";
 	public static final String CONSUL_DNS_PORT_BRIDGE_BINDING_DEFAULT = "53";
-	
-	
+	public static final String CONSUL_DNS_OFF_PROPERTY = "consul.dns.off";
+	public static final String CONSUL_DNS_OFF_DEFAULT = null;
+
 }

--- a/dockerunit-core/pom.xml
+++ b/dockerunit-core/pom.xml
@@ -3,7 +3,7 @@
 <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.qzagarese</groupId>
   <artifactId>dockerunit-core</artifactId>
-  <version>1.0.0-GA</version>
+  <version>1.0.1-GA-SNAPSHOT</version>
   <name>dockerunit-core</name>
   <description>Java Framework for testing of dockerised applications and services. Core package</description>
   <url>https://github.com/qzagarese/dockerunit</url>

--- a/dockerunit-core/pom.xml
+++ b/dockerunit-core/pom.xml
@@ -3,7 +3,7 @@
 <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.qzagarese</groupId>
   <artifactId>dockerunit-core</artifactId>
-  <version>1.0.1-GA-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <name>dockerunit-core</name>
   <description>Java Framework for testing of dockerised applications and services. Core package</description>
   <url>https://github.com/qzagarese/dockerunit</url>

--- a/examples/spring-boot-example/README.md
+++ b/examples/spring-boot-example/README.md
@@ -31,8 +31,6 @@ If you are on Linux but you have a different ip (for example `172.17.0.1`), run 
 
 If you are on Mac, run the following:
 
-`./mvnw test -P container-tests -Ddocker.host=localhost -Ddocker.bridge.ip=172.17.0.1` 
-
-Thank you for trying this :-)
+`./mvnw test -P container-tests -Ddocker.host=localhost -Ddocker.bridge.ip=172.17.0.1 -Dconsul.dns.off` 
 
    

--- a/examples/spring-boot-example/pom.xml
+++ b/examples/spring-boot-example/pom.xml
@@ -30,13 +30,13 @@
 		<dependency>
 			<groupId>com.github.qzagarese</groupId>
 			<artifactId>dockerunit-core</artifactId>
-			<version>1.0.1-GA-SNAPSHOT</version>
+			<version>1.0.1-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.github.qzagarese</groupId>
 			<artifactId>dockerunit-consul</artifactId>
-			<version>1.0.1-GA-SNAPSHOT</version>
+			<version>1.0.1-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/examples/spring-boot-example/pom.xml
+++ b/examples/spring-boot-example/pom.xml
@@ -30,13 +30,13 @@
 		<dependency>
 			<groupId>com.github.qzagarese</groupId>
 			<artifactId>dockerunit-core</artifactId>
-			<version>1.0.0-GA</version>
+			<version>1.0.1-GA-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.github.qzagarese</groupId>
 			<artifactId>dockerunit-consul</artifactId>
-			<version>1.0.0-GA</version>
+			<version>1.0.1-GA-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.github.qzagarese</groupId>
   <artifactId>dockerunit</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.1-GA-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <name>dockerunit</name>
   <description>Java Framework for testing of dockerised applications and services</description>
   <url>https://github.com/qzagarese/dockerunit</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.github.qzagarese</groupId>
   <artifactId>dockerunit</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.0-GA</version>
+  <version>1.0.1-GA-SNAPSHOT</version>
   <name>dockerunit</name>
   <description>Java Framework for testing of dockerised applications and services</description>
   <url>https://github.com/qzagarese/dockerunit</url>


### PR DESCRIPTION
Allows you to disable consul dns to prevent crashes on Mac (MacOS does not allow port bindings that explicitly reference the docker bridge ip).

How to try this:

1. Pull this branch
2. `mvn clean install -Dgpg.skip=true`
3. `cd examples/spring-boot-example/`
4. Build the example image: `mvn clean package docker:build`
5. Run the test: `mvn test -P container-tests -Ddocker.bridge.ip=172.17.0.1 -Ddocker.host=localhost -Dconsul.dns.off`