### PR TITLE
Containers ip on consul

### DIFF
--- a/dockerunit-consul/pom.xml
+++ b/dockerunit-consul/pom.xml
@@ -3,7 +3,7 @@
 <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.qzagarese</groupId>
   <artifactId>dockerunit-consul</artifactId>
-  <version>1.0.1</version>
+  <version>1.1.0-SNAPSHOT</version>
   <name>dockerunit-consul</name>
   <description>Java Framework for testing of dockerised applications and services. Consul+registrator based service discovery package.</description>
   <url>https://github.com/qzagarese/dockerunit</url>
@@ -15,7 +15,8 @@
   </developers>
 
   <properties>
-    <dockerunit.core.version>1.0.1</dockerunit.core.version>
+    <dockerunit.core.version>1.1.0-SNAPSHOT</dockerunit.core.version>
+    <dockerjava.version>3.0.14</dockerjava.version>
     <vertx.core.version>3.5.4</vertx.core.version>
     <lombok.version>1.16.6</lombok.version>
   </properties>
@@ -38,6 +39,12 @@
       <groupId>com.github.qzagarese</groupId>
       <artifactId>dockerunit-core</artifactId>
       <version>${dockerunit.core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java</artifactId>
+      <version>${dockerjava.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDescriptor.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDescriptor.java
@@ -22,7 +22,7 @@ import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryCo
 public class ConsulDescriptor {
 
 
-    static final int CONSUL_DNS_PORT = 8600;
+    static final int CONSUL_DNS_PORT = 53;
     static final int CONSUL_PORT = 8500;
 
     private static final Logger logger = Logger.getLogger(ConsulDescriptor.class.getSimpleName());
@@ -50,22 +50,23 @@ public class ConsulDescriptor {
 
         bindings.bind(consulPort, Binding.bindPort(8500));
 
-        return cmd.withExposedPorts(ports)
-                .withPortBindings(bindings)
-                .withCmd("agent", "-dev", "-client=0.0.0.0", "-enable-script-checks");
-
-    }
-
-    private void activateDns(List<ExposedPort> ports, Ports bindings) {
         ExposedPort dnsPort = ExposedPort.udp(CONSUL_DNS_PORT);
         ports.add(dnsPort);
 
-        int dnsBridgePort = Integer.parseInt(System.getProperty(CONSUL_DNS_PORT_BRIDGE_BINDING,
-                CONSUL_DNS_PORT_BRIDGE_BINDING_DEFAULT));
+        return cmd.withExposedPorts(ports)
+                .withPortBindings(bindings)
+//                .withCmd("agent", "-dev", "-client=0.0.0.0", "-enable-script-checks", "-dns-port=53");
+                .withCmd("sh", "-c", "consul agent -dev -client=0.0.0.0 -enable-script-checks -dns-port=53");
+    }
 
-        bindings.bind(dnsPort, Binding.bindIpAndPort(
-                System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT),
-                dnsBridgePort));
+    private void activateDns(List<ExposedPort> ports, Ports bindings) {
+//        ExposedPort dnsPort = ExposedPort.udp(CONSUL_DNS_PORT);
+//        ports.add(dnsPort);
+
+//        int dnsBridgePort = Integer.parseInt(System.getProperty(CONSUL_DNS_PORT_BRIDGE_BINDING,
+//                CONSUL_DNS_PORT_BRIDGE_BINDING_DEFAULT));
+//
+//        bindings.bind(dnsPort, Binding.bindPort(dnsBridgePort));
     }
 
 }

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDiscoveryConfig.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDiscoveryConfig.java
@@ -2,7 +2,9 @@ package com.github.qzagarese.dockerunit.discovery.consul;
 
 import com.github.qzagarese.dockerunit.annotation.Use;
 
-@Use(service=ConsulDescriptor.class, containerPrefix="consul")
+import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryConfig.CONSUL_CONTAINER_NAME;
+
+@Use(service=ConsulDescriptor.class, containerPrefix=CONSUL_CONTAINER_NAME)
 @Use(service=RegistratorDescriptor.class, containerPrefix="registrator")
 public class ConsulDiscoveryConfig {
 
@@ -17,5 +19,5 @@ public class ConsulDiscoveryConfig {
 	public static final String CONSUL_DNS_PORT_BRIDGE_BINDING_DEFAULT = "53";
 	public static final String CONSUL_DNS_ENABLED_PROPERTY = "consul.dns.enabled";
 	public static final String CONSUL_DNS_ENABLED_DEFAULT = "true";
-
+	public static final String CONSUL_CONTAINER_NAME = "consul";
 }

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDiscoveryProvider.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDiscoveryProvider.java
@@ -114,12 +114,10 @@ public class ConsulDiscoveryProvider implements DiscoveryProvider {
 	}
 
 	private int findPort(InspectContainerResponse response, List<ServiceRecord> records) {
-		ServiceRecord record = records.stream()
+		Optional<ServiceRecord> record = records.stream()
 			.filter(r -> this.matchPort(r, response))
-			.findFirst()
-			.orElseThrow(() ->  
-				new RuntimeException("Cannot find exposed port/ip for container " + response.getName()));
-		return record.getPort();
+			.findFirst();
+		return record.isPresent() ? record.get().getPort() : records.stream().findFirst().map(sr -> sr.getPort()).orElse(0);
 	}
 
 	private boolean matchPort(ServiceRecord record, InspectContainerResponse r) {

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ContainerUtils.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ContainerUtils.java
@@ -1,0 +1,65 @@
+package com.github.qzagarese.dockerunit.discovery.consul;
+
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.ContainerNetwork;
+import com.github.dockerjava.api.model.ContainerNetworkSettings;
+import com.github.dockerjava.api.model.NetworkSettings;
+import com.github.qzagarese.dockerunit.internal.docker.DefaultDockerClientProvider;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+public class ContainerUtils {
+
+    private static final com.github.dockerjava.api.DockerClient dockerClient = new DefaultDockerClientProvider().getClient();
+
+
+    public static Optional<String> extractBridgeIpAddress(ContainerNetworkSettings settings) {
+        return extractIp(settings.getNetworks());
+    }
+
+    public static Optional<String> extractBridgeIpAddress(NetworkSettings settings) {
+        return extractIp(settings.getNetworks());
+    }
+
+    public static Optional<Integer> extractMappedPort(int port, NetworkSettings networkSettings) {
+        return networkSettings.getPorts().getBindings().entrySet().stream()
+                .filter(entry -> entry.getKey().getPort() == port)
+                .map(Map.Entry::getValue)
+                .filter(bindings -> bindings != null && bindings.length > 0)
+                .findFirst()
+                .map(bindings ->  parsePort(bindings[0].getHostPortSpec())
+                        .orElseThrow(() -> new RuntimeException(String.format("Could not parse mapping for exposed port ", port))));
+    }
+
+    public static Container getConsulContainer() {
+        return dockerClient.listContainersCmd().exec().stream()
+                .filter(c -> isConsul(c))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException(("Could not detect the Consul container.")));
+    }
+
+
+    private static boolean isConsul(Container c) {
+        return Arrays.stream(c.getNames()).anyMatch(s -> s.equals(ConsulDiscoveryConfig.CONSUL_CONTAINER_NAME));
+    }
+
+
+    private static Optional<String> extractIp(Map<String, ContainerNetwork> networks) {
+        return Optional.ofNullable(networks.entrySet().stream()
+                .filter(network -> "bridge".equals(network.getKey()))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException(("Container is not connected to the bridge network.")))
+                .getValue()
+                .getIpAddress());
+    }
+
+    private static Optional<Integer> parsePort(String s) {
+        try {
+            return Optional.of(Integer.parseInt(s));
+        } catch (NumberFormatException nfe) {
+            return Optional.empty();
+        }
+    }
+}

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/RegistratorDescriptor.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/RegistratorDescriptor.java
@@ -19,7 +19,7 @@ public class RegistratorDescriptor {
 	public CreateContainerCmd config(CreateContainerCmd cmd) {
 		String dockerBridgeIp = System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT);
 		return cmd.withBinds(new Bind("/var/run/docker.sock", new Volume("/tmp/docker.sock")))
-				.withCmd("-ip=" + dockerBridgeIp, "-cleanup","consul://" + dockerBridgeIp + ":" + CONSUL_PORT);
+				.withCmd("-ip=" + dockerBridgeIp, "-cleanup", "-internal", "consul://" + dockerBridgeIp + ":" + CONSUL_PORT);
 	}
 	
 }

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/RegistratorDescriptor.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/RegistratorDescriptor.java
@@ -19,7 +19,11 @@ public class RegistratorDescriptor {
 	public CreateContainerCmd config(CreateContainerCmd cmd) {
 		String dockerBridgeIp = System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT);
 		return cmd.withBinds(new Bind("/var/run/docker.sock", new Volume("/tmp/docker.sock")))
-				.withCmd("-ip=" + dockerBridgeIp, "-cleanup", "-internal", "consul://" + dockerBridgeIp + ":" + CONSUL_PORT);
+				.withCmd(
+//						"-ip="+ dockerBridgeIp,
+						"-cleanup",
+						"-internal",
+						"consul://" + dockerBridgeIp +  ":"+  CONSUL_PORT);
 	}
 	
 }

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ServiceRecord.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ServiceRecord.java
@@ -23,7 +23,10 @@ public class ServiceRecord {
 	
 	@JsonProperty("ServicePort")
 	private final int port;
-	
+
+	@JsonProperty("ServiceAddress")
+	private String serviceAddress;
+
 	@JsonProperty("Service")
 	private final Service service;
 	

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/annotation/impl/UseConsulDnsExtensionInterpreter.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/annotation/impl/UseConsulDnsExtensionInterpreter.java
@@ -1,18 +1,48 @@
 package com.github.qzagarese.dockerunit.discovery.consul.annotation.impl;
 
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.ContainerNetwork;
+import com.github.qzagarese.dockerunit.annotation.ExtensionInterpreter;
+import com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryConfig;
+import com.github.qzagarese.dockerunit.discovery.consul.annotation.UseConsulDns;
+import com.github.qzagarese.dockerunit.internal.ServiceDescriptor;
+import com.github.qzagarese.dockerunit.internal.docker.DefaultDockerClientProvider;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
 import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryConfig.DOCKER_BRIDGE_IP_DEFAULT;
 import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryConfig.DOCKER_BRIDGE_IP_PROPERTY;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.qzagarese.dockerunit.annotation.ExtensionInterpreter;
-import com.github.qzagarese.dockerunit.discovery.consul.annotation.UseConsulDns;
-import com.github.qzagarese.dockerunit.internal.ServiceDescriptor;
-
 public class UseConsulDnsExtensionInterpreter implements ExtensionInterpreter<UseConsulDns> {
+
+
+    private final com.github.dockerjava.api.DockerClient dockerClient;
+
+    public UseConsulDnsExtensionInterpreter() {
+        dockerClient = new DefaultDockerClientProvider().getClient();
+    }
 
     @Override
     public CreateContainerCmd build(ServiceDescriptor sd, CreateContainerCmd cmd, UseConsulDns t) {
-        return cmd.withDns(System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT));
+        ListContainersCmd listCmd = dockerClient.listContainersCmd();
+        Map<String, List<String>> filters = listCmd.getFilters();
+        filters.put("name", Arrays.asList(ConsulDiscoveryConfig.CONSUL_CONTAINER_NAME));
+
+        Container container = listCmd.exec().stream()
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException(("Could not detect the Consul container.")));
+
+        Map.Entry<String, ContainerNetwork> bridge = container.getNetworkSettings().getNetworks().entrySet().stream()
+                .filter(entry -> entry.getKey().equals("bridge"))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException(("Container is not connected to the bridge network.")));
+
+        String ipAddress = bridge.getValue().getIpAddress();
+        return cmd.withDns(ipAddress != null ? ipAddress : System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT));
     }
 
 }

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/annotation/impl/UseConsulDnsExtensionInterpreter.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/annotation/impl/UseConsulDnsExtensionInterpreter.java
@@ -1,48 +1,31 @@
 package com.github.qzagarese.dockerunit.discovery.consul.annotation.impl;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.command.ListContainersCmd;
-import com.github.dockerjava.api.model.Container;
-import com.github.dockerjava.api.model.ContainerNetwork;
 import com.github.qzagarese.dockerunit.annotation.ExtensionInterpreter;
-import com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryConfig;
+import com.github.qzagarese.dockerunit.discovery.consul.ContainerUtils;
 import com.github.qzagarese.dockerunit.discovery.consul.annotation.UseConsulDns;
 import com.github.qzagarese.dockerunit.internal.ServiceDescriptor;
 import com.github.qzagarese.dockerunit.internal.docker.DefaultDockerClientProvider;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 
 import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryConfig.DOCKER_BRIDGE_IP_DEFAULT;
 import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryConfig.DOCKER_BRIDGE_IP_PROPERTY;
 
 public class UseConsulDnsExtensionInterpreter implements ExtensionInterpreter<UseConsulDns> {
 
-
-    private final com.github.dockerjava.api.DockerClient dockerClient;
-
-    public UseConsulDnsExtensionInterpreter() {
-        dockerClient = new DefaultDockerClientProvider().getClient();
-    }
-
     @Override
     public CreateContainerCmd build(ServiceDescriptor sd, CreateContainerCmd cmd, UseConsulDns t) {
-        ListContainersCmd listCmd = dockerClient.listContainersCmd();
-        Map<String, List<String>> filters = listCmd.getFilters();
-        filters.put("name", Arrays.asList(ConsulDiscoveryConfig.CONSUL_CONTAINER_NAME));
+        Optional<String> dnsIp = Optional.ofNullable(ContainerUtils.extractBridgeIpAddress(ContainerUtils.getConsulContainer()
+                .getNetworkSettings()).get());
 
-        Container container = listCmd.exec().stream()
-                .findFirst()
-                .orElseThrow(() -> new RuntimeException(("Could not detect the Consul container.")));
-
-        Map.Entry<String, ContainerNetwork> bridge = container.getNetworkSettings().getNetworks().entrySet().stream()
-                .filter(entry -> entry.getKey().equals("bridge"))
-                .findFirst()
-                .orElseThrow(() -> new RuntimeException(("Container is not connected to the bridge network.")));
-
-        String ipAddress = bridge.getValue().getIpAddress();
-        return cmd.withDns(ipAddress != null ? ipAddress : System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT));
+        List<String> dnsList = Arrays.asList(Optional.ofNullable(cmd.getDns()).orElse(new String[0]));
+        dnsList.add(dnsIp.orElse(System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT)));
+        return cmd.withDns(dnsList);
     }
+
+
 
 }

--- a/dockerunit-core/pom.xml
+++ b/dockerunit-core/pom.xml
@@ -3,7 +3,7 @@
 <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.qzagarese</groupId>
   <artifactId>dockerunit-core</artifactId>
-  <version>1.0.1</version>
+  <version>1.1.0-SNAPSHOT</version>
   <name>dockerunit-core</name>
   <description>Java Framework for testing of dockerised applications and services. Core package</description>
   <url>https://github.com/qzagarese/dockerunit</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.github.qzagarese</groupId>
   <artifactId>dockerunit</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.1</version>
+  <version>1.1.0-SNAPSHOT</version>
   <name>dockerunit</name>
   <description>Java Framework for testing of dockerised applications and services</description>
   <url>https://github.com/qzagarese/dockerunit</url>


### PR DESCRIPTION
Discovery changes quite a lot, however these changes are backward compatible.
Hereafter what changes:
- Registrator now registers containers ips and exposed ports instead of the docker bridge plus the mapped port. This means that you need to use `@PortBinding` only for those ports that you need to hit from your tests.
-  Instead of the docker bridge, `@UseConsulDns` now sets the consul container ip as primary dns for your services, so this should work on Mac too (needs verification).