### PR TITLE
Docker java 3.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Changed
+
+- Bump docker-java to 3.1.1
+
+## 1.0.1 [01 Mar 2019]
+
+### Added
+
+- New boolean flag `-Dconsul.dns.enabled` to disable consul DNS (fixes [#12](https://github.com/qzagarese/dockerunit/issues/12)) 
+
+## 1.0.0 [06 Feb 2019]
+
+_Initial Release_

--- a/README.md
+++ b/README.md
@@ -1,31 +1,43 @@
 # Dockerunit - JUnit for Docker containers
 
-Dockerunit is an extensible framework for testing of dockerised services and applications.
-It is based on JUnit and it allows linking of Docker images to Java tests by means of Java annotations.
+Dockerunit is an extensible framework for testing of dockerised services and 
+applications.
+It is based on JUnit and it allows linking of Docker images to Java tests by 
+means of Java annotations.
 You can think of Dockerunit as of a docker-compose for Java tests.
 
-Dockerunit leverages useful tools like [docker-java](https://github.com/docker-java/docker-java), [Consul](https://www.consul.io/) and [registrator](https://github.com/gliderlabs/registrator) to provide the following main features:
+Dockerunit leverages useful tools like 
+[docker-java](https://github.com/docker-java/docker-java), 
+[Consul](https://www.consul.io/) and 
+[registrator](https://github.com/gliderlabs/registrator) to provide the 
+following main features:
 1. Automatic pull of images referencing a registry.
-2. Service discovery based on Consul + registrator (alternative discovery providers can be plugged in).
+2. Service discovery based on Consul + registrator (alternative discovery 
+providers can be plugged in).
 3. Container port mapping.
-4. Volume mapping allowing relative paths from test classpath, so you can easily mount test config files.
-5. Support for multiple instances of a service, so you can test how your services would work on environments like [Kubernetes](https://kubernetes.io/).
-6. A simple mechanism similar to the [Java Validation Framework](https://jcp.org/en/jsr/detail?id=303) for you to add your own annotations.
+4. Volume mapping allowing relative paths from test classpath, so you can 
+easily mount test config files.
+5. Support for multiple instances of a service, so you can test how your 
+services would work on environments like [Kubernetes](https://kubernetes.io/).
+6. A simple mechanism similar to the 
+[Java Validation Framework](https://jcp.org/en/jsr/detail?id=303) for you to 
+add your own annotations.
  
 ## Usage
-You can enable Dockerunit by adding the following dependencies to you POM file.
+You can enable Dockerunit by adding the following dependencies to you POM file 
+(set `dockerunit.version` property to the version you intend to use).
 ```xml
 <dependency>
   <groupId>com.github.qzagarese</groupId>
   <artifactId>dockerunit-core</artifactId>
-  <version>1.0.1</version>
+  <version>${dockerunit.version}</version>
   <scope>test</scope>
 </dependency>
 
 <dependency>
   <groupId>com.github.qzagarese</groupId>
   <artifactId>dockerunit-consul</artifactId>
-  <version>1.0.1</version>
+  <version>${dockerunit.version}</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -36,7 +48,8 @@ Building tests with Dockerunit consists of two main steps:
 2. Using your service from your test.
 
 ### 1. Defining your service descriptor
-A service descriptor is a class that instructs Dockerunit about how to create Docker containers, given a Docker image that you have previously created.
+A service descriptor is a class that instructs Dockerunit about how to create 
+Docker containers, given a Docker image that you have previously created.
 Here is a simple descriptor for a Spring service that is listening on port 8080.
 
 ```java
@@ -68,25 +81,37 @@ public class MyServiceDescriptor {
 
 There are two ways to enable Dockerunit in your tests:
 
-1. As a runner using the `@RunWith` annotation as follows: `@RunWith(DockerUnitRunner.class)`.
+1. As a runner using the `@RunWith` annotation as follows: 
+`@RunWith(DockerUnitRunner.class)`.
 2. As a rule using the `@Rule` or the `@ClassRule` annotation.  
 
-Using the runner allows you to combine startup of containers at a class and a test execution level.
-This means that you can start one or more services only once, if they are used by all the tests in your test class, 
-and at the same time you can spin up the remaining ones when the test that needs them is going to execute.
+Using the runner allows you to combine startup of containers at a class and a 
+test execution level.
+This means that you can start one or more services only once, if they are used 
+by all the tests in your test class, 
+and at the same time you can spin up the remaining ones when the test that 
+needs them is going to execute.
 
-On the other hand, you can only use one runner at the time, so you cannot use Dockerunit in conjunction with other testing frameworks if you are using this approach.
+On the other hand, you can only use one runner at the time, so you cannot use 
+Dockerunit in conjunction with other testing frameworks if you are using this 
+approach.
 
-Using a rule allows you to perform service startup/discovery either once per test class execution (`@ClassRule`) or before each test (`@Rule`). 
+Using a rule allows you to perform service startup/discovery either once per 
+test class execution (`@ClassRule`) or before each test (`@Rule`). 
 
-Moreover, you can use rules with JUnit `@SuiteClasses`, which allows you to perform service startup/discovery once and then execute several test classes rapidly.
+Moreover, you can use rules with JUnit `@SuiteClasses`, which allows you to 
+perform service startup/discovery once and then execute several test classes 
+rapidly.
 
-Finally, using a rule allows you to combine Dockerunit with other runner-based testing frameworks. 
+Finally, using a rule allows you to combine Dockerunit with other runner-based 
+testing frameworks. 
 
 
 It's now time to write an actual test.
-The following examples use RestAssured, but you can choose any library to hit your endpoints.
-We are testing that our service starts correctly and the health-check responds with a 200 status code.
+The following examples use RestAssured, but you can choose any library to hit 
+your endpoints.
+We are testing that our service starts correctly and the health-check responds 
+with a 200 status code.
 
 Here is an example that uses `DockerUnitRunner`:
 ```java
@@ -172,9 +197,12 @@ public class MyServiceTest {
 
 This is Dockerunit in a nutshell.
 1. It uses your descriptors to instantiate one or more Docker containers.
-2. It makes sure that each of them started successfully and that the discovery provider (for now Consul) can monitor their state.
-3. It provides you a ServiceContext instance that you can use to select the services and endpoints to hit.
-4. It cleans up the containers after the the test execution (also when the test fails unexpectedly).
+2. It makes sure that each of them started successfully and that the discovery 
+provider (for now Consul) can monitor their state.
+3. It provides you a ServiceContext instance that you can use to select the 
+services and endpoints to hit.
+4. It cleans up the containers after the the test execution (also when the 
+test fails unexpectedly).
   
 What next? You can look at some examples [here](./examples/).
   

--- a/dockerunit-consul/pom.xml
+++ b/dockerunit-consul/pom.xml
@@ -1,9 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-<modelVersion>4.0.0</modelVersion>
-  <groupId>com.github.qzagarese</groupId>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.qzagarese</groupId>
+    <artifactId>dockerunit</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+  </parent>
+
   <artifactId>dockerunit-consul</artifactId>
-  <version>1.0.1</version>
+
   <name>dockerunit-consul</name>
   <description>Java Framework for testing of dockerised applications and services. Consul+registrator based service discovery package.</description>
   <url>https://github.com/qzagarese/dockerunit</url>
@@ -15,7 +21,7 @@
   </developers>
 
   <properties>
-    <dockerunit.core.version>1.0.1</dockerunit.core.version>
+    <dockerunit.core.version>1.1.0-SNAPSHOT</dockerunit.core.version>
     <vertx.core.version>3.5.4</vertx.core.version>
     <lombok.version>1.16.6</lombok.version>
   </properties>
@@ -26,12 +32,6 @@
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
-
-  <scm>
-    <connection>scm:http://github.com/qzagarese/dockerunit.git</connection>
-    <developerConnection>scm:http://github.com/qzagarese/dockerunit.git</developerConnection>
-    <url>http://github.com/qzagarese/dockerunit.git</url>
-  </scm>	
 
   <dependencies>
     <dependency>
@@ -53,86 +53,29 @@
   </dependencies>
 
   <build>
-    <sourceDirectory>src/main/java</sourceDirectory>
-
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
       </plugin>
 
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
-
   </build>
-  
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
   
 </project>
 

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDescriptor.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDescriptor.java
@@ -2,6 +2,7 @@ package com.github.qzagarese.dockerunit.discovery.consul;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.Ports.Binding;
 import com.github.qzagarese.dockerunit.annotation.ContainerBuilder;
@@ -34,8 +35,8 @@ public class ConsulDescriptor {
 
         ExposedPort consulPort = ExposedPort.tcp(CONSUL_PORT);
         ports.add(consulPort);
-
-        Ports bindings = cmd.getPortBindings();
+        
+        Ports bindings = cmd.getHostConfig().getPortBindings();
         if (bindings == null) {
             bindings = new Ports();
         }
@@ -50,10 +51,11 @@ public class ConsulDescriptor {
 
         bindings.bind(consulPort, Binding.bindPort(8500));
 
-        return cmd.withExposedPorts(ports)
-                .withPortBindings(bindings)
-                .withCmd("agent", "-dev", "-client=0.0.0.0", "-enable-script-checks");
+        HostConfig hc = cmd.getHostConfig().withPortBindings(bindings);
 
+        return cmd.withHostConfig(hc)
+                .withExposedPorts(ports)
+                .withCmd("agent", "-dev", "-client=0.0.0.0", "-enable-script-checks");
     }
 
     private void activateDns(List<ExposedPort> ports, Ports bindings) {
@@ -68,4 +70,7 @@ public class ConsulDescriptor {
                 dnsBridgePort));
     }
 
+        
+	}
+	
 }

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDescriptor.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/ConsulDescriptor.java
@@ -69,8 +69,4 @@ public class ConsulDescriptor {
                 System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT),
                 dnsBridgePort));
     }
-
-        
-	}
-	
 }

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/RegistratorDescriptor.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/RegistratorDescriptor.java
@@ -6,6 +6,7 @@ import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryCo
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Volume;
 import com.github.qzagarese.dockerunit.annotation.ContainerBuilder;
 import com.github.qzagarese.dockerunit.annotation.Image;
@@ -17,9 +18,12 @@ public class RegistratorDescriptor {
 
 	@ContainerBuilder
 	public CreateContainerCmd config(CreateContainerCmd cmd) {
+		HostConfig hc = cmd.getHostConfig().withBinds(new Bind("/var/run/docker.sock", new Volume("/tmp/docker.sock")));
+
 		String dockerBridgeIp = System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT);
-		return cmd.withBinds(new Bind("/var/run/docker.sock", new Volume("/tmp/docker.sock")))
-				.withCmd("-ip=" + dockerBridgeIp, "-cleanup","consul://" + dockerBridgeIp + ":" + CONSUL_PORT);
+
+		return cmd.withHostConfig(hc)
+				.withCmd("-ip=" + dockerBridgeIp, "-cleanup", "consul://" + dockerBridgeIp + ":" + CONSUL_PORT);
 	}
 	
 }

--- a/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/annotation/impl/UseConsulDnsExtensionInterpreter.java
+++ b/dockerunit-consul/src/main/java/com/github/qzagarese/dockerunit/discovery/consul/annotation/impl/UseConsulDnsExtensionInterpreter.java
@@ -4,6 +4,7 @@ import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryCo
 import static com.github.qzagarese.dockerunit.discovery.consul.ConsulDiscoveryConfig.DOCKER_BRIDGE_IP_PROPERTY;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.HostConfig;
 import com.github.qzagarese.dockerunit.annotation.ExtensionInterpreter;
 import com.github.qzagarese.dockerunit.discovery.consul.annotation.UseConsulDns;
 import com.github.qzagarese.dockerunit.internal.ServiceDescriptor;
@@ -12,7 +13,10 @@ public class UseConsulDnsExtensionInterpreter implements ExtensionInterpreter<Us
 
     @Override
     public CreateContainerCmd build(ServiceDescriptor sd, CreateContainerCmd cmd, UseConsulDns t) {
-        return cmd.withDns(System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT));
+        HostConfig hc = cmd.getHostConfig()
+                .withDns(System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT));
+
+        return cmd.withHostConfig(hc);
     }
 
 }

--- a/dockerunit-core/pom.xml
+++ b/dockerunit-core/pom.xml
@@ -1,9 +1,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-<modelVersion>4.0.0</modelVersion>
-  <groupId>com.github.qzagarese</groupId>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.qzagarese</groupId>
+    <artifactId>dockerunit</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+  </parent>
+
   <artifactId>dockerunit-core</artifactId>
-  <version>1.0.1</version>
+  <version>1.1.0-SNAPSHOT</version>
+
   <name>dockerunit-core</name>
   <description>Java Framework for testing of dockerised applications and services. Core package</description>
   <url>https://github.com/qzagarese/dockerunit</url>
@@ -16,7 +23,7 @@
 
   <properties>
     <junit.version>4.12</junit.version>
-    <dockerjava.version>3.0.14</dockerjava.version>
+    <dockerjava.version>3.1.1</dockerjava.version>
     <lombok.version>1.16.6</lombok.version>
   </properties>
 
@@ -26,12 +33,6 @@
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
-
-  <scm>
-    <connection>scm:http://github.com/qzagarese/dockerunit.git</connection>
-    <developerConnection>scm:http://github.com/qzagarese/dockerunit.git</developerConnection>
-    <url>http://github.com/qzagarese/dockerunit.git</url>
-  </scm>	
 
   <dependencies>
     <dependency>
@@ -53,85 +54,28 @@
   </dependencies>
 
   <build>
-    <sourceDirectory>src/main/java</sourceDirectory>
-
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
       </plugin>
 
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
-
   </build>
-  
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
   
 </project>

--- a/dockerunit-core/src/main/java/com/github/qzagarese/dockerunit/annotation/impl/PortBindingExtensionInterpreter.java
+++ b/dockerunit-core/src/main/java/com/github/qzagarese/dockerunit/annotation/impl/PortBindingExtensionInterpreter.java
@@ -3,8 +3,11 @@ package com.github.qzagarese.dockerunit.annotation.impl;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.Ports.Binding;
 import com.github.qzagarese.dockerunit.annotation.ExtensionInterpreter;
@@ -16,20 +19,26 @@ public class PortBindingExtensionInterpreter implements ExtensionInterpreter<Por
 
     @Override
     public CreateContainerCmd build(ServiceDescriptor sd, CreateContainerCmd cmd, PortBinding pb) {
-        List<ExposedPort> ports = new ArrayList<>(Arrays.asList(cmd.getExposedPorts()));
-        ExposedPort containerPort = pb.protocol()
-            .equals(Protocol.TCP) ? ExposedPort.tcp(pb.exposedPort()) : ExposedPort.udp(pb.exposedPort());
-        ports.add(containerPort);
-        
-        Ports bindings = cmd.getPortBindings();
-        if (bindings == null) {
-            bindings = new Ports();
-        }
-        bindings.bind(containerPort, pb.hostIp()
-            .isEmpty() ? Binding.bindPort(pb.hostPort()) : Binding.bindIpAndPort(pb.hostIp(), pb.hostPort()));
+        ExposedPort containerPort = toExposedPort(pb);
 
-        return cmd.withExposedPorts(ports)
-            .withPortBindings(bindings);
+        List<ExposedPort> ports = new ArrayList<>(Arrays.asList(cmd.getExposedPorts()));
+        ports.add(containerPort);
+
+        HostConfig hc = cmd.getHostConfig();
+
+        Ports bindings = Optional.ofNullable(hc.getPortBindings()).orElse(new Ports());
+        bindings.bind(containerPort, toHostBinding(pb));
+
+        return cmd.withExposedPorts(ports).withHostConfig(hc.withPortBindings(bindings));
     }
 
+    private ExposedPort toExposedPort(PortBinding pb) {
+        return pb.protocol() == Protocol.TCP ? ExposedPort.tcp(pb.exposedPort()) : ExposedPort.udp(pb.exposedPort());
+    }
+
+    private Binding toHostBinding(PortBinding pb) {
+        return pb.hostIp().isEmpty()
+               ? Binding.bindPort(pb.hostPort())
+               : Binding.bindIpAndPort(pb.hostIp(), pb.hostPort());
+    }
 }

--- a/dockerunit-core/src/main/java/com/github/qzagarese/dockerunit/annotation/impl/PublishPortsExtensionInterpreter.java
+++ b/dockerunit-core/src/main/java/com/github/qzagarese/dockerunit/annotation/impl/PublishPortsExtensionInterpreter.java
@@ -1,6 +1,7 @@
 package com.github.qzagarese.dockerunit.annotation.impl;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.HostConfig;
 import com.github.qzagarese.dockerunit.annotation.ExtensionInterpreter;
 import com.github.qzagarese.dockerunit.annotation.PublishPorts;
 import com.github.qzagarese.dockerunit.internal.ServiceDescriptor;
@@ -9,7 +10,9 @@ public class PublishPortsExtensionInterpreter implements ExtensionInterpreter<Pu
 
     @Override
     public CreateContainerCmd build(ServiceDescriptor sd, CreateContainerCmd cmd, PublishPorts pp) {
-        return cmd.withPublishAllPorts(true);
+        HostConfig hc = cmd.getHostConfig().withPublishAllPorts(true);
+
+        return cmd.withHostConfig(hc);
     }
 
 }

--- a/dockerunit-core/src/main/java/com/github/qzagarese/dockerunit/annotation/impl/VolumeExtensionInterpreter.java
+++ b/dockerunit-core/src/main/java/com/github/qzagarese/dockerunit/annotation/impl/VolumeExtensionInterpreter.java
@@ -3,10 +3,12 @@ package com.github.qzagarese.dockerunit.annotation.impl;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.AccessMode;
 import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.HostConfig;
 import com.github.qzagarese.dockerunit.annotation.ExtensionInterpreter;
 import com.github.qzagarese.dockerunit.annotation.Volume;
 import com.github.qzagarese.dockerunit.internal.ServiceDescriptor;
@@ -15,23 +17,27 @@ public class VolumeExtensionInterpreter implements ExtensionInterpreter<Volume> 
 
     @Override
     public CreateContainerCmd build(ServiceDescriptor sd, CreateContainerCmd cmd, Volume v) {
-    	Bind[] binds = cmd.getBinds();
-    	
-    	String hostPath = v.useClasspath() 
-    			? Thread.currentThread().getContextClassLoader()
-    					.getResource(v.host()).getPath()
-    			: v.host();
-    	
-    	Bind bind = new Bind(hostPath, 
-    			new com.github.dockerjava.api.model.Volume(v.container()), 
-    			AccessMode.fromBoolean(v.accessMode().equals(Volume.AccessMode.RW)));
-    	
-    	List<Bind> bindsList = new ArrayList<>();
-    	if(binds != null) {
-    		bindsList.addAll(Arrays.asList(binds));
-    	} 
-   		bindsList.add(bind);  	
-        return cmd.withBinds(bindsList);
+        List<Bind> binds = Optional.ofNullable(cmd.getHostConfig().getBinds())
+                .map(Arrays::asList)
+                .map(ArrayList::new)
+                .orElse(new ArrayList<>());
+
+        binds.add(
+                new Bind(
+                        toHostPath(v),
+                        new com.github.dockerjava.api.model.Volume(v.container()),
+                        AccessMode.fromBoolean(v.accessMode() == Volume.AccessMode.RW)
+                )
+        );
+
+        HostConfig hc = cmd.getHostConfig().withBinds(binds);
+
+        return cmd.withHostConfig(hc);
     }
 
+    private String toHostPath(Volume v) {
+        return v.useClasspath()
+               ? Thread.currentThread().getContextClassLoader().getResource(v.host()).getPath()
+               : v.host();
+    }
 }

--- a/dockerunit-core/src/main/java/com/github/qzagarese/dockerunit/internal/reflect/DefaultDependencyDescriptorBuilder.java
+++ b/dockerunit-core/src/main/java/com/github/qzagarese/dockerunit/internal/reflect/DefaultDependencyDescriptorBuilder.java
@@ -27,7 +27,7 @@ public class DefaultDependencyDescriptorBuilder implements UsageDescriptorBuilde
 
     @Override
     public UsageDescriptor buildDescriptor(FrameworkMethod method) {
-       return buildDescriptor((AnnotatedElement) method.getMethod());
+       return buildDescriptor(method.getMethod());
     }
 
     
@@ -138,7 +138,7 @@ public class DefaultDependencyDescriptorBuilder implements UsageDescriptorBuilde
                 && m.getParameterTypes()[0].equals(CreateContainerCmd.class)
                 && m.getReturnType().equals(CreateContainerCmd.class))
             .findFirst();
-        return opt.orElseGet(() -> null);
+        return opt.orElse(null);
     }
 
     private int extractReplicas(Use use) {

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <groupId>com.github.qzagarese</groupId>
   <artifactId>dockerunit</artifactId>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <version>1.0.1</version>
+
   <name>dockerunit</name>
   <description>Java Framework for testing of dockerised applications and services</description>
   <url>https://github.com/qzagarese/dockerunit</url>
@@ -15,19 +17,106 @@
     </developer>
   </developers>
 
+  <scm>
+    <connection>scm:http://github.com/qzagarese/dockerunit.git</connection>
+    <developerConnection>scm:http://github.com/qzagarese/dockerunit.git</developerConnection>
+    <url>http://github.com/qzagarese/dockerunit.git</url>
+  </scm>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <modules>
     <module>dockerunit-core</module>
     <module>dockerunit-consul</module>
   </modules>
+
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.5.1</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <version>1.6.7</version>
+          <extensions>true</extensions>
+          <configuration>
+            <serverId>ossrh</serverId>
+            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.2.1</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.9.1</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+
+        <plugin>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.5</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- Bump docker-java to 3.1.1 (the main change)
- Add `CHANGELOG.md`
- Add missing `parent` pom element to modules
- Moved maven plugin configs to `pluginManagement` in parent pom
- Moved `distributionManagement` to parent pom
- Removed version from child modules (they get the parent version by default) - This one I'm not too sure if it's what is intended... not sure if all modules should be kept in sync when it comes to versions or if they should be versioned independently... Usually it's a good idea to keep parent poms and modules versioned independently.