### PR TITLE
Fixing Trailing comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ import com.jayway.restassured.RestAssured;
 public class MyServiceTest {
 
 	@Test
-  // Selects the previously defined descriptor
+        // Selects the previously defined descriptor
 	@Use(service=MyServiceDescriptor.class) 
 	public void healthCheckShouldReturn200(ServiceContext context) {
 		// Gets the service based on value in the @Named annotation
@@ -144,7 +144,7 @@ public class MyServiceTest {
 				The port could be dynamic if @PublishPorts is used */
 				.baseUri("http://" + si.getIp() + ":" + si.getPort()) 
 			.when()
-        // Hits the health-check endpoint
+                                // Hits the health-check endpoint
 				.get("/health-check")  
 			.then()
 				.assertThat()
@@ -192,7 +192,7 @@ public class MyServiceTest {
 				The port could be dynamic if @PublishPorts is used */
 				.baseUri("http://" + si.getIp() + ":" + si.getPort()) 
 			.when()
-        // Hits the health-check endpoint
+                                // Hits the health-check endpoint
 				.get("/health-check") 
 			.then()
 				.assertThat()

--- a/README.md
+++ b/README.md
@@ -125,11 +125,13 @@ import com.github.qzagarese.dockerunit.ServiceInstance;
 import com.github.qzagarese.dockerunit.annotation.Use;
 import com.jayway.restassured.RestAssured;
 
-@RunWith(DockerUnitRunner.class) // Enables Dockerunit
+// Enables Dockerunit
+@RunWith(DockerUnitRunner.class) 
 public class MyServiceTest {
 
 	@Test
-	@Use(service=MyServiceDescriptor.class) // Selects the previously defined descriptor
+  // Selects the previously defined descriptor
+	@Use(service=MyServiceDescriptor.class) 
 	public void healthCheckShouldReturn200(ServiceContext context) {
 		// Gets the service based on value in the @Named annotation
 		Service s = context.getService("my-spring-service"); 
@@ -142,7 +144,8 @@ public class MyServiceTest {
 				The port could be dynamic if @PublishPorts is used */
 				.baseUri("http://" + si.getIp() + ":" + si.getPort()) 
 			.when()
-				.get("/health-check") // Hits the health-check endpoint 
+        // Hits the health-check endpoint
+				.get("/health-check")  
 			.then()
 				.assertThat()
 				.statusCode(200);
@@ -162,7 +165,8 @@ import com.github.qzagarese.dockerunit.ServiceInstance;
 import com.github.qzagarese.dockerunit.annotation.Use;
 import com.jayway.restassured.RestAssured;
 
-@Use(service=MyServiceDescriptor.class) // Selects the previously defined descriptor
+// Selects the previously defined descriptor
+@Use(service=MyServiceDescriptor.class) 
 public class MyServiceTest {
 
 	@Rule
@@ -188,7 +192,8 @@ public class MyServiceTest {
 				The port could be dynamic if @PublishPorts is used */
 				.baseUri("http://" + si.getIp() + ":" + si.getPort()) 
 			.when()
-				.get("/health-check") // Hits the health-check endpoint 
+        // Hits the health-check endpoint
+				.get("/health-check") 
 			.then()
 				.assertThat()
 				.statusCode(200);


### PR DESCRIPTION
> From the famous book Code Complete:

The comments have to be aligned so that they do not interfere with the visual structure of the code. If you don't align them neatly, they'll make your listing look like it's been through a washing machine.

Endline comments tend to be hard to format. It takes time to align them. Such time is not spent learning more about the code; it's dedicated solely to the tedious task of pressing the spacebar or tab key.

Endline comments are also hard to maintain. If the code on any line containing an endline comment grows, it bumps the comment farther out, and all the other endline comments will have to bumped out to match. Styles that are hard to maintain aren't maintained.

Endline comments also tend to be cryptic. The right side of the line doesn't offer much room and the desire to keep the comment on one line means the comment must be short. Work then goes into making the line as short as possible instead of as clear as possible. The comment usually ends up as cryptic as possible.

A systemic problem with endline comments is that it's hard to write a meaningful comment for one line of code. Most endline comments just repeat the line of code, which hurts more than it helps.